### PR TITLE
Update git link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🚀 EzQt_App
 
-[![Repository](https://img.shields.io/badge/Repository-GitHub-blue?style=for-the-badge&logo=github)](https://github.com/neuraaak/ezqt_app)
+[![Repository](https://img.shields.io/badge/Repository-GitHub-blue?style=for-the-badge&logo=github)](https://github.com/neuraaak/EzQt-App)
 [![PyPI](https://img.shields.io/badge/PyPI-ezqt_app-green?style=for-the-badge&logo=pypi)](https://pypi.org/project/EzQt_App/)
-[![Tests](https://img.shields.io/badge/Tests-240%2B%20passing-green?style=for-the-badge&logo=pytest)](https://github.com/neuraaak/ezqt_app/actions)
+[![Tests](https://img.shields.io/badge/Tests-240%2B%20passing-green?style=for-the-badge&logo=pytest)](https://github.com/neuraaak/EzQt-App/actions)
 
 A lightweight Python framework based on PySide6 to quickly build modern desktop applications, with integrated resource, theme, and reusable component management.
 
@@ -237,7 +237,7 @@ ezqt_app/
 
 ### **Development Installation**
 ```bash
-git clone https://github.com/neuraaak/ezqt_app.git
+git clone https://github.com/neuraaak/EzQt-App.git
 cd ezqt_app
 pip install -e ".[dev]"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@ EzQt_App is a Python framework designed to facilitate the creation of modern Qt 
 pip install ezqt_app
 
 # Or locally
-git clone https://github.com/neuraaak/ezqt_app.git
+git clone https://github.com/neuraaak/EzQt-App.git
 cd ezqt_app
 pip install .
 ```


### PR DESCRIPTION
Update Git repository links in documentation to match the correct repository name `EzQt-App`.

The previous links used `ezqt_app`, which was inconsistent with the actual repository URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-04171f67-6a77-4097-85a5-52ca39de7f2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04171f67-6a77-4097-85a5-52ca39de7f2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>